### PR TITLE
Adding arm64 into goreleaser.yaml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,6 +16,7 @@ builds:
 
   goarch:
     - amd64
+    - arm64
 
 archives:
 - name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"


### PR DESCRIPTION
Hopefully fix for https://github.com/mbenabda/helm-local-chart-version/issues/20 ~~, but I have no idea how to test it.~~

EDIT:
```
lestr@localhost:/tmp/helm-local-chart-version(enable-arm64-build):∑ ls -laR dist/helm-local-chart-version_*
dist/helm-local-chart-version_darwin_amd64_v1:
total 5504
drwxr-xr-x 3 lestr wheel      96 Jun  2 22:38 .
drwxr-xr-x 9 lestr wheel     288 Jun  2 22:38 ..
-rwxr-xr-x 1 lestr staff 5632064 Jun  2 22:38 local-chart-version

dist/helm-local-chart-version_darwin_arm64:
total 5500
drwxr-xr-x 3 lestr wheel      96 Jun  2 22:38 .
drwxr-xr-x 9 lestr wheel     288 Jun  2 22:38 ..
-rwxr-xr-x 1 lestr staff 5628930 Jun  2 22:38 local-chart-version

dist/helm-local-chart-version_linux_amd64_v1:
total 5004
drwxr-xr-x 3 lestr wheel      96 Jun  2 22:38 .
drwxr-xr-x 9 lestr wheel     288 Jun  2 22:38 ..
-rwxr-xr-x 1 lestr staff 5124096 Jun  2 22:38 local-chart-version

dist/helm-local-chart-version_linux_arm64:
total 4928
drwxr-xr-x 3 lestr wheel      96 Jun  2 22:38 .
drwxr-xr-x 9 lestr wheel     288 Jun  2 22:38 ..
-rwxr-xr-x 1 lestr staff 5046272 Jun  2 22:38 local-chart-version
```

Now we have arm64 and amd64 binaries for Linux and osx.